### PR TITLE
fix: Use `NULLS FIRST` for incremental replication

### DIFF
--- a/tap_athena/client.py
+++ b/tap_athena/client.py
@@ -39,3 +39,4 @@ class AthenaStream(SQLStream):
     """The Stream class for Athena."""
 
     connector_class = AthenaConnector
+    supports_nulls_first = True


### PR DESCRIPTION
<blockquote>
<p>The default null ordering is <code class="code">NULLS LAST</code>, regardless of ascending or descending sort order.</p>
</blockquote>

References:
* https://docs.aws.amazon.com/athena/latest/ug/select.html#select-parameters
* https://trino.io/docs/current/sql/select.html#order-by-clause